### PR TITLE
Actor movement simplified through Pivot removal.

### DIFF
--- a/2018/06-09-grid-based-movement/pawns/Actor.tscn
+++ b/2018/06-09-grid-based-movement/pawns/Actor.tscn
@@ -96,11 +96,7 @@ playback/active = false
 playback/repeat = false
 playback/speed = 1.0
 
-[node name="Pivot" type="Position2D" parent="." index="2"]
-
-_sections_unfolded = [ "Transform" ]
-
-[node name="Sprite" type="Sprite" parent="Pivot" index="0"]
+[node name="Sprite" type="Sprite" parent="." index="2"]
 
 position = Vector2( 1.43051e-06, -1.90735e-06 )
 texture = ExtResource( 2 )

--- a/2018/06-09-grid-based-movement/pawns/Actor.tscn
+++ b/2018/06-09-grid-based-movement/pawns/Actor.tscn
@@ -10,7 +10,7 @@ length = 0.1
 loop = false
 step = 0.01
 tracks/0/type = "value"
-tracks/0/path = NodePath("Pivot/Sprite:position")
+tracks/0/path = NodePath("Sprite:position")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -29,7 +29,7 @@ length = 0.25
 loop = false
 step = 0.05
 tracks/0/type = "value"
-tracks/0/path = NodePath("Pivot/Sprite:self_modulate")
+tracks/0/path = NodePath("Sprite:self_modulate")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -41,7 +41,7 @@ tracks/0/keys = {
 "values": [ Color( 1, 1, 1, 1 ), Color( 1, 0.9375, 0, 1 ), Color( 1, 1, 1, 1 ) ]
 }
 tracks/1/type = "value"
-tracks/1/path = NodePath("Pivot/Sprite:position")
+tracks/1/path = NodePath("Sprite:position")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/imported = false
@@ -53,7 +53,7 @@ tracks/1/keys = {
 "values": [ Vector2( 1.43051e-06, -1.90735e-06 ), Vector2( 1.43051e-06, -1.90735e-06 ), Vector2( 0, -20 ), Vector2( 1.43051e-06, -1.90735e-06 ) ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("Pivot/Sprite:scale")
+tracks/2/path = NodePath("Sprite:scale")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false

--- a/2018/06-09-grid-based-movement/pawns/actor.gd
+++ b/2018/06-09-grid-based-movement/pawns/actor.gd
@@ -24,7 +24,8 @@ func get_input_direction():
 	)
 
 func update_look_direction(direction):
-	$Pivot/Sprite.rotation = direction.angle()
+	#$Pivot/Sprite.rotation = direction.angle()
+	$Sprite.rotation = direction.angle()
 
 func move_to(target_position):
 	set_process(false)
@@ -33,8 +34,12 @@ func move_to(target_position):
 	# Move the node to the target cell instantly,
 	# and animate the sprite moving from the start to the target cell
 	var move_direction = (target_position - position).normalized()
-	$Tween.interpolate_property($Pivot, "position", - move_direction * 32, Vector2(), $AnimationPlayer.current_animation_length, Tween.TRANS_LINEAR, Tween.EASE_IN)
-	position = target_position
+		
+	$Tween.interpolate_property(
+		self,"position",
+		position,target_position,
+		$AnimationPlayer.current_animation_length,
+		Tween.TRANS_LINEAR, Tween.EASE_IN)
 
 	$Tween.start()
 

--- a/2018/06-09-grid-based-movement/pawns/actor.gd
+++ b/2018/06-09-grid-based-movement/pawns/actor.gd
@@ -24,7 +24,6 @@ func get_input_direction():
 	)
 
 func update_look_direction(direction):
-	#$Pivot/Sprite.rotation = direction.angle()
 	$Sprite.rotation = direction.angle()
 
 func move_to(target_position):


### PR DESCRIPTION
This small change eliminates the use of a Pivot (Position2D) to move the character. The position is updated after the animation ends, which makes no difference since the update has already been done in the Grid.

**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [x] You updated the docs or changelog.


Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
The removal of one node and a the removal of unnecessary calculations.


**Does this PR introduce a breaking change?**
No


## New feature or change ##


**What is the current behavior?** 
The _Actor_ uses a Position2D node to reposition the Sprite node.

The Node tree is currently:
├── Actor
│      ├── Pivot (Position 2D)
│              ├── Sprite

**What is the new behavior?**
├── Actor
│       ├── Sprite


**Other information**
