### PR TITLE
Fix healing typo to correct behavior

### DIFF
--- a/2018/04-24-finite-state-machine/player/health/health.gd
+++ b/2018/04-24-finite-state-machine/player/health/health.gd
@@ -44,7 +44,7 @@ func take_damage(amount, effect=null):
 
 func heal(amount):
 	health += amount
-	health = max(health, max_health)
+	health = min(health, max_health)
 	emit_signal("health_changed", health)
 #	print("%s got healed by %s points. Health: %s/%s" % [get_name(), amount, health, max_health])
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [x] You updated the docs or changelog.


Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
Just a slight typo fix.

**Does this PR introduce a breaking change?**
I wouldn't call it that.

## New feature or change ##
Fixes #71. 

**What is the current behavior?** 
When you heal, it automatically heals you the full amount, regardless of how much you've healed or how high your hit points are. Further, if you heal beyond the max health, it remains at the higher value instead of being reduced to the max health allowed.


**What is the new behavior?**
Correcting the above by making it only be able to go up to the max health, and when healing, it selects the current health if it's still below the max health after healing because the healed amount doesn't bring up to the max health.


**Other information**
